### PR TITLE
Potential fix for code scanning alert no. 1: Stored cross-site scripting

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -61,9 +61,10 @@ export function getAllBlogPosts(): BlogPost[] {
   const allPostsData = fileNames
     .filter(fileName => fileName.endsWith('.md'))
     .map((fileName) => {
-      const slug = fileName.replace(/\.md$/, '')
+      // Sanitize slug: allow only URL-safe characters (alphanumeric, dash, underscore)
+      const slugRaw = fileName.replace(/\.md$/, '')
+      const slug = slugRaw.replace(/[^a-zA-Z0-9\-_]/g, '')
       const fullPath = path.join(postsDirectory, fileName)
-      const fileContents = fs.readFileSync(fullPath, 'utf8')
       const { data, content } = parseFrontmatter(fileContents)
 
       return {
@@ -86,7 +87,9 @@ export function getAllBlogPosts(): BlogPost[] {
 
 export function getBlogPostBySlug(slug: string): BlogPost | null {
   try {
-    const fullPath = path.join(postsDirectory, `${slug}.md`)
+    // Sanitize slug before use
+    const safeSlug = slug.replace(/[^a-zA-Z0-9\-_]/g, '')
+    const fullPath = path.join(postsDirectory, `${safeSlug}.md`)
     const fileContents = fs.readFileSync(fullPath, 'utf8')
     const { data, content } = parseFrontmatter(fileContents)
 


### PR DESCRIPTION
Potential fix for [https://github.com/dominikake/personal_blog/security/code-scanning/1](https://github.com/dominikake/personal_blog/security/code-scanning/1)

The best way to fix the issue is to sanitize the slug field before using it in route generation and rendering. Given that slugs should consist solely of URL-safe characters (typically lowercase alphanumeric, hyphens, and underscores), we should validate and transform file names to match expected slug patterns.

- In `src/lib/blog.ts`, ensure that when extracting slugs from file names, any dangerous or nonconforming characters are stripped or replaced.
- Sanitize the `slug` value so it always matches a strict pattern like `/^[a-zA-Z0-9\-_]+$/`.
- Optionally, reject or skip malformed slugs (e.g., log a warning and don't expose those blog posts).
- These edits can be made in the `.map()` function in the `getAllBlogPosts` function, and in the `getBlogPostBySlug` function when constructing slugs.
- No new dependencies are strictly required: a simple regular expression suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
